### PR TITLE
Scan original image

### DIFF
--- a/android/src/main/java/com/reactnativeqrimagereader/QrImageReaderModule.kt
+++ b/android/src/main/java/com/reactnativeqrimagereader/QrImageReaderModule.kt
@@ -72,14 +72,20 @@ class QrImageReaderModule(reactContext: ReactApplicationContext) : ReactContextB
     }
 
     var bitmap = getBitmapFromFileString(imagePath)
-    bitmap = bitmap?.let { scaleDown(it, 400f) };
 
     if (bitmap == null) {
       decodeError(map, promise)
       return
     }
-    
-    val codeString = readCodeFromBitmap(bitmap)
+
+    var codeString = readCodeFromBitmap(bitmap)
+
+    if (codeString == null) {
+      // If no code was found, try to scale down the image and read the code again
+      bitmap = scaleDown(bitmap, 400f)
+      codeString = readCodeFromBitmap(bitmap)
+    }
+
     if (codeString == null) {
       decodeError(map, promise)
       return
@@ -116,7 +122,7 @@ class QrImageReaderModule(reactContext: ReactApplicationContext) : ReactContextB
   }
 
   private fun scaleDown(realImage: Bitmap, maxImageSize: Float,
-                        filter: Boolean = true): Bitmap? {
+                        filter: Boolean = true): Bitmap {
     val minDimension = min(realImage.width, realImage.height);
     val maxDimension = max(realImage.width, realImage.height);
 

--- a/ios/QrImageReader.m
+++ b/ios/QrImageReader.m
@@ -48,6 +48,22 @@ NSString* decodeError = @"decode_error";
   return newImage;
 }
 
+- (NSString *) readCodeFromImage:(CGImageRef) imageToDecode error: (NSError **) error {
+  
+  ZXLuminanceSource *source = [[ZXCGImageLuminanceSource alloc] initWithCGImage:imageToDecode];
+  ZXBinaryBitmap *bitmap = [ZXBinaryBitmap binaryBitmapWithBinarizer:[ZXHybridBinarizer binarizerWithSource:source]];
+  ZXDecodeHints *hints = [ZXDecodeHints hints];
+  
+  ZXMultiFormatReader *reader = [ZXMultiFormatReader reader];
+  ZXResult *result = [reader decode:bitmap
+                              hints:hints
+                              error:error];
+  if (result) {
+    return result.text;
+  }
+  return nil;
+}
+
 RCT_REMAP_METHOD(decode,
                  decodeOptions: (nonnull NSDictionary *)options
                  withResolver:(RCTPromiseResolveBlock)resolve
@@ -76,18 +92,12 @@ RCT_REMAP_METHOD(decode,
     return;
   }
   
-  ZXLuminanceSource *source = [[ZXCGImageLuminanceSource alloc] initWithCGImage:imageToDecode];
-  ZXBinaryBitmap *bitmap = [ZXBinaryBitmap binaryBitmapWithBinarizer:[ZXHybridBinarizer binarizerWithSource:source]];
   NSError *error = nil;
-  ZXDecodeHints *hints = [ZXDecodeHints hints];
   
-  ZXMultiFormatReader *reader = [ZXMultiFormatReader reader];
-  ZXResult *result = [reader decode:bitmap
-                              hints:hints
-                              error:&error];
+  NSString* result = [self readCodeFromImage:imageToDecode error:&error];
+  
   if (result) {
-    NSString *contents = result.text;
-    [resultObj setObject: contents forKey:resultKey];
+    [resultObj setObject: result forKey:resultKey];
     resolve(resultObj);
     // The barcode format, such as a QR code or UPC-A
     //    ZXBarcodeFormat format = result.barcodeFormat;

--- a/ios/QrImageReader.m
+++ b/ios/QrImageReader.m
@@ -79,11 +79,12 @@ RCT_REMAP_METHOD(decode,
   
   NSURL *url = [NSURL URLWithString: imagePath];
   NSString *path = [url path];
+  UIImage* uiImage = nil;
   
   BOOL doesFileExist = [fileManager fileExistsAtPath: path];
   if (doesFileExist) {
-    UIImage* uiImage = [[UIImage alloc] initWithContentsOfFile: path];
-    imageToDecode = [self compressImage: uiImage].CGImage;
+    uiImage = [[UIImage alloc] initWithContentsOfFile: path];
+    imageToDecode = uiImage.CGImage;
   }
   else {
     // reject
@@ -95,6 +96,11 @@ RCT_REMAP_METHOD(decode,
   NSError *error = nil;
   
   NSString* result = [self readCodeFromImage:imageToDecode error:&error];
+  
+  if (result == nil) {
+    imageToDecode = [self compressImage: uiImage].CGImage;
+    result = [self readCodeFromImage:imageToDecode error:&error];
+  }
   
   if (result) {
     [resultObj setObject: result forKey:resultKey];


### PR DESCRIPTION
This fixes some cases where the library cannot find codes when they should.

This was due to scaling of images to allow for high res and skinny images to be decoded.
This PR will now scan the original image, without downscaling, and if no results are found, it will rescan with the downscaling (the previous version)