### PR TITLE
Fix zxing-core 3.4.0 crashes on Android < 7.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -128,6 +128,6 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-  implementation 'com.google.zxing:core:3.4.1'
+  implementation 'com.google.zxing:core:3.3.3'
   implementation 'androidx.appcompat:appcompat:1.0.2'
 }


### PR DESCRIPTION
Downgrade `zxing` to `3.3.3` can fix the crash.
https://github.com/zxing/zxing/issues/1170#issuecomment-494806839